### PR TITLE
fix(images): use basePath for image paths in owasp-zap-setup page

### DIFF
--- a/src/app/wiki/owasp-zap-setup/page.tsx
+++ b/src/app/wiki/owasp-zap-setup/page.tsx
@@ -2,6 +2,10 @@ import { ContentPageLayout, P, H2, H3, Ul } from '@/components/content/ContentPa
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import Link from 'next/link';
 import Image from 'next/image';
+import getConfig from 'next/config';
+
+const { publicRuntimeConfig } = getConfig();
+const basePath = publicRuntimeConfig.basePath || '';
 
 const LinkStyle = "text-primary hover:text-primary/80 hover:underline";
 
@@ -66,7 +70,7 @@ export default function OwaspZapSetupPage() {
             
             <figure className="my-6 text-center">
                 <Image
-                    src="/pics/owasp-installation/Screenshot 2025-07-03 183340.png"
+                    src={`${basePath}/pics/owasp-installation/Screenshot 2025-07-03 183340.png`}
                     alt="Главный интерфейс приложения OWASP ZAP, показывающий экран приветствия и главный прокси, работающий на localhost:8081."
                     width={800}
                     height={450}
@@ -86,7 +90,7 @@ export default function OwaspZapSetupPage() {
             
             <figure className="my-6 text-center">
                 <Image
-                    src="/pics/owasp-installation/Screenshot 2025-07-03 183430.png"
+                    src={`${basePath}/pics/owasp-installation/Screenshot 2025-07-03 183430.png`}
                     alt="Главный графический интерфейс OWASP ZAP 2.8.0, показывающий экран приветствия и различные панели навигации."
                     width={800}
                     height={450}
@@ -99,7 +103,7 @@ export default function OwaspZapSetupPage() {
 
             <figure className="my-6 text-center">
                 <Image
-                    src="/pics/owasp-installation/Screenshot 2025-07-03 183538.png"
+                    src={`${basePath}/pics/owasp-installation/Screenshot 2025-07-03 183538.png`}
                     alt="Конфигурация локального прокси OWASP ZAP, показывающая адрес и порт по умолчанию для интеграции с браузером."
                     width={800}
                     height={450}
@@ -112,7 +116,7 @@ export default function OwaspZapSetupPage() {
 
             <figure className="my-6 text-center">
                 <Image
-                    src="/pics/owasp-installation/Screenshot 2025-07-03 183629.png"
+                    src={`${basePath}/pics/owasp-installation/Screenshot 2025-07-03 183629.png`}
                     alt="Создание SSL-сертификата в OWASP ZAP."
                     width={800}
                     height={450}
@@ -129,7 +133,7 @@ export default function OwaspZapSetupPage() {
 
             <figure className="my-6 text-center">
                 <Image
-                    src="/pics/owasp-installation/Screenshot 2025-07-03 183715.png"
+                    src={`${basePath}/pics/owasp-installation/Screenshot 2025-07-03 183715.png`}
                     alt="Диалоговое окно настроек соединения Firefox для ручной настройки прокси."
                     width={800}
                     height={450}
@@ -139,7 +143,7 @@ export default function OwaspZapSetupPage() {
 
             <figure className="my-6 text-center">
                 <Image
-                    src="/pics/owasp-installation/Screenshot 2025-07-03 183849.png"
+                    src={`${basePath}/pics/owasp-installation/Screenshot 2025-07-03 183849.png`}
                     alt="Диалоговое окно настроек соединения Firefox для ручной настройки прокси, с подробными полями для HTTP, HTTPS и SOCKS прокси."
                     width={800}
                     height={450}
@@ -152,7 +156,7 @@ export default function OwaspZapSetupPage() {
 
             <figure className="my-6 text-center">
                 <Image
-                    src="/pics/owasp-installation/Screenshot 2025-07-03 184009.png"
+                    src={`${basePath}/pics/owasp-installation/Screenshot 2025-07-03 184009.png`}
                     alt="Настройка about:config в Firefox для разрешения перехвата прокси для localhost."
                     width={800}
                     height={450}
@@ -174,7 +178,7 @@ export default function OwaspZapSetupPage() {
 
             <figure className="my-6 text-center">
                 <Image
-                    src="/pics/owasp-installation/Screenshot 2025-07-03 184214.png"
+                    src={`${basePath}/pics/owasp-installation/Screenshot 2025-07-03 184214.png`}
                     alt="Рабочий процесс настройки OWASP ZAP и Firefox Developer Edition."
                     width={800}
                     height={450}
@@ -191,7 +195,7 @@ export default function OwaspZapSetupPage() {
 
             <figure className="my-6 text-center">
                 <Image
-                    src="/pics/owasp-installation/Screenshot 2025-07-03 184245.png"
+                    src={`${basePath}/pics/owasp-installation/Screenshot 2025-07-03 184245.png`}
                     alt="Успешная установка OWASP ZAP."
                     width={800}
                     height={450}


### PR DESCRIPTION
- Updated image `src` attributes in `src/app/wiki/owasp-zap-setup/page.tsx` to use `basePath` from `next/config`.
- This should resolve 404 errors for images on GitHub Pages deployments.